### PR TITLE
fix: launch_configuration always triggers it

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -126,7 +126,7 @@ resource "aws_autoscaling_group" "this" {
         checkpoint_percentages = var.instance_refresh_checkpoint_percentages
         min_healthy_percentage = 90
       }
-      triggers = ["launch_configuration"]
+      triggers = []
     }
   }
 


### PR DESCRIPTION
> Warning: 'launch_configuration' always triggers an instance refresh and can be removed