### PR TITLE
feat: expose associate_public_ip_address 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,12 +46,12 @@ data "cloudinit_config" "user_data" {
 }
 
 resource "aws_launch_configuration" "this" {
-  name_prefix                   = var.name_prefix
-  image_id                      = var.image_id
-  instance_type                 = var.instance_type
-  user_data                     = data.cloudinit_config.user_data.rendered
-  iam_instance_profile          = var.iam_instance_profile
-  associate_public_ip_addresses = var.associate_public_ip_addresses
+  name_prefix                 = var.name_prefix
+  image_id                    = var.image_id
+  instance_type               = var.instance_type
+  user_data                   = data.cloudinit_config.user_data.rendered
+  iam_instance_profile        = var.iam_instance_profile
+  associate_public_ip_address = var.associate_public_ip_address
 
   key_name = var.key_name
 

--- a/main.tf
+++ b/main.tf
@@ -46,11 +46,12 @@ data "cloudinit_config" "user_data" {
 }
 
 resource "aws_launch_configuration" "this" {
-  name_prefix          = var.name_prefix
-  image_id             = var.image_id
-  instance_type        = var.instance_type
-  user_data            = data.cloudinit_config.user_data.rendered
-  iam_instance_profile = var.iam_instance_profile
+  name_prefix                   = var.name_prefix
+  image_id                      = var.image_id
+  instance_type                 = var.instance_type
+  user_data                     = data.cloudinit_config.user_data.rendered
+  iam_instance_profile          = var.iam_instance_profile
+  associate_public_ip_addresses = var.associate_public_ip_addresses
 
   key_name = var.key_name
 

--- a/variables.tf
+++ b/variables.tf
@@ -92,6 +92,10 @@ See: https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-max-instance-life
 EOF
 }
 
+variable "associate_public_ip_addresses" {
+  default = false
+}
+
 variable "tags" {
   type = list(object({
     key                 = string

--- a/variables.tf
+++ b/variables.tf
@@ -92,7 +92,7 @@ See: https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-max-instance-life
 EOF
 }
 
-variable "associate_public_ip_addresses" {
+variable "associate_public_ip_address" {
   default = false
 }
 


### PR DESCRIPTION
Since version 4.17.0 it always defaults to false, see https://github.com/hashicorp/terraform-provider-aws/pull/17695